### PR TITLE
PROD-3233 CORS -> master

### DIFF
--- a/iac/uni-nav.deploy.yml
+++ b/iac/uni-nav.deploy.yml
@@ -57,6 +57,35 @@ Resources:
                 SigningBehavior: always
                 SigningProtocol: sigv4
 
+    ResponseHeadersPolicy:
+        Type: AWS::CloudFront::ResponseHeadersPolicy
+        Properties:
+            ResponseHeadersPolicyConfig:
+                Name: !Sub ${AWS::StackName}-security-response-headers-policy
+                CorsConfig:
+                    AccessControlAllowCredentials: false
+                    AccessControlAllowHeaders:
+                        Items:
+                            - '*'
+                    AccessControlAllowMethods:
+                        Items: 
+                            - GET
+                            - HEAD
+                            - OPTIONS
+                    AccessControlAllowOrigins:
+                        # TODO: figure out a way to load this in from a shared config
+                        # so that we don't have to manually deploy any time we add a
+                        # new tool
+                        Items:
+                            - !Sub https://${Domain}
+                            - !Sub https://community.${Domain}
+                            - !Sub https://discussions.${Domain}
+                            - !Sub https://local.${Domain}
+                            - !Sub https://platform-ui.${Domain}
+                            - !Sub https://software.${Domain}
+                            - !If [IsProd, https://topcoder.privatetalent.cloud, https://topcoder.privatetalent-dev.cloud]
+                    OriginOverride: true
+
     Cdn:
         Type: AWS::CloudFront::Distribution
         Properties: 
@@ -86,6 +115,7 @@ Resources:
                         QueryString: false
                         Cookies:
                             Forward: none
+                    ResponseHeadersPolicyId: !Ref ResponseHeadersPolicy
                 ViewerCertificate: 
                     AcmCertificateArn: !FindInMap
                         - DomainMap


### PR DESCRIPTION
This PR adds the allowed origins to a custom response header policy that is assigned to the cloudfront distribution.