### PR TITLE
Make default host configurable

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,1 +1,4 @@
-export const DEFAULT_HOST_URL = 'https://topcoder.com'
+// https://vitejs.dev/guide/env-and-mode.html
+// use `import.meta.env` to access env variables
+// use VITE_ prefix in .env to expose variable to the app
+export const DEFAULT_HOST_URL = import.meta.env.VITE_DEFAULT_HOST_URL ?? 'https://topcoder.com'


### PR DESCRIPTION
This PR uses `VITE_DEFAULT_HOST_URL` from the env to make the DEFAULT_HOST configurable by environment (eg. by setting VITE_DEFAULT_HOST_URL when building).