### PR TITLE
Improve interactions for the marketing navigation hover state

### DIFF
--- a/src/lib/components/LinksMenu.module.scss
+++ b/src/lib/components/LinksMenu.module.scss
@@ -9,9 +9,8 @@
   :global(.navLink) {
     text-decoration: none;
     position: relative;
-  
-    &:global(.hover):before,
-    &:hover:before {
+
+    &:before {
       content: "";
       display: block;
       position: absolute;

--- a/src/lib/components/LinksMenu.svelte
+++ b/src/lib/components/LinksMenu.svelte
@@ -58,4 +58,5 @@
       {menuItem.label}
     </a>
   {/each}
+  <slot />
 </div>

--- a/src/lib/marketing-navigation/components/HoverMenu.module.scss
+++ b/src/lib/marketing-navigation/components/HoverMenu.module.scss
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   z-index: 9;
-  
+
   background: #fff;
   box-shadow: 0px 6px 24px rgba(0, 0, 0, 0.1);
   border-radius: 0px 0px 8px 8px;
@@ -16,6 +16,30 @@
   font-size: 14px;
   line-height: 22px;
   color: #2A2A2A;
+
+  visibility: hidden;
+  opacity: 0;
+  z-index: -1;
+  transform: translateY(5px);
+  pointer-events: none;
+
+  // transition out
+  transition: opacity 0.2s ease-out 0.15s,
+    visibility 0s ease-out 0.35s,
+    transform 0.15s ease-out 0.15s;
+
+  :global(*:hover) ~ &, &:hover {
+    opacity: 1;
+    visibility: visible;
+    z-index: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+
+    // transition in
+    transition: opacity 0.2s ease-in 0.15s,
+        visibility 0s ease-in 0.1s,
+        transform 0.15s ease-in 0.15s;
+  }
 }
 
 .hoverMenuInner {

--- a/src/lib/marketing-navigation/components/HoverMenu.svelte
+++ b/src/lib/marketing-navigation/components/HoverMenu.svelte
@@ -1,13 +1,30 @@
 <script lang="ts">
   import type { NavMenuItem } from 'lib/functions/nav-menu-item.model';
   import { navUrl } from 'lib/utils/paths';
+    import { onMount } from 'svelte';
   import styles from './HoverMenu.module.scss';
 
   export let mainDescription = '';
   export let menuItems: NavMenuItem[] = [];
+  export let isHovering: boolean = false;
+
+  let elWrap: HTMLElement | undefined;
+
+  function handleMouseEv(ev: MouseEvent) {
+    isHovering = ev.type === 'mouseenter'
+  }
+
+  onMount(() => {
+    elWrap?.addEventListener('mouseenter', handleMouseEv)
+    elWrap?.addEventListener('mouseleave', handleMouseEv)
+    return () => {
+        elWrap?.removeEventListener('mouseenter', handleMouseEv)
+        elWrap?.removeEventListener('mouseleave', handleMouseEv)
+    }
+  })
 </script>
 
-<div class={styles.hoverMenuWrap}>
+<div class={styles.hoverMenuWrap} bind:this={elWrap}>
   <div class={styles.hoverMenuInner}>
     <p class={styles.mainDesc}>
       {mainDescription}

--- a/src/lib/marketing-navigation/components/NavigationBar.svelte
+++ b/src/lib/marketing-navigation/components/NavigationBar.svelte
@@ -1,42 +1,38 @@
 <script type="ts">
-  import type { NavMenuItem } from 'lib/functions/nav-menu-item.model';
-  import { classnames } from 'lib/utils/classnames';
-  import HoverMenu from './HoverMenu.svelte';
-  import LinksMenu from '../../components/LinksMenu.svelte';
-  import styles from './NavigationBar.module.scss';
-  import PopupMenu from 'lib/components/PopupMenu.svelte';
+    import type { NavMenuItem } from 'lib/functions/nav-menu-item.model';
+    import { classnames } from 'lib/utils/classnames';
+    import HoverMenu from './HoverMenu.svelte';
+    import LinksMenu from '../../components/LinksMenu.svelte';
+    import styles from './NavigationBar.module.scss';
 
-  export let style: 'primary'|'secondary'|'ternary';
-  export let menuItems: NavMenuItem[] = [];
-  export let activeRoute: NavMenuItem;
+    export let style: 'primary'|'secondary'|'ternary';
+    export let menuItems: NavMenuItem[] = [];
+    export let activeRoute: NavMenuItem;
 
-  let popupIsVisible: boolean;
-  let hoveredElement: HTMLElement | undefined;
-  let hoveredMenuItem: NavMenuItem;
+    let popupIsVisible: boolean;
+    let hoveredElement: HTMLElement | undefined;
+    let hoveredMenuItem: NavMenuItem;
 </script>
 
 <nav class={classnames(styles.navbar, styles[style])}>
-  <slot name="logo"></slot>
+    <slot name="logo"></slot>
 
-  <LinksMenu
-    className={styles.mainNav}
-    menuItems={menuItems}
-    activeRoute={activeRoute}
-    bind:hoveredMenuItem={hoveredMenuItem}
-    bind:hoveredElement={hoveredElement}
-    isPopupMenuActive={popupIsVisible}
-  />
+    <LinksMenu
+        className={styles.mainNav}
+        menuItems={menuItems}
+        activeRoute={activeRoute}
+        bind:hoveredMenuItem={hoveredMenuItem}
+        bind:hoveredElement={hoveredElement}
+        isPopupMenuActive={popupIsVisible}
+    >
+        {#if !activeRoute}
+            <HoverMenu
+                menuItems={hoveredMenuItem?.children}
+                mainDescription={hoveredMenuItem?.description}
+                bind:isHovering={popupIsVisible}
+            />
+        {/if}
+    </LinksMenu>
 
-  <slot name="auth"></slot>
-
-  <PopupMenu
-    targetEl={hoveredElement}
-    bind:isVisible={popupIsVisible}
-    class={styles.hoverMenu}
-  >
-    <HoverMenu
-      menuItems={hoveredMenuItem?.children}
-      mainDescription={hoveredMenuItem?.description}
-    />
-  </PopupMenu>
+    <slot name="auth"></slot>
 </nav>


### PR DESCRIPTION
Improves the hover interaction for the marketing navigation. Moves the hover popup closer (in the DOM) to the navigation elements so I can do the whole interaction in css only.
Still relies on js for marking the hovered navigation item as active/in hover state.