### PR TITLE
Integration fixes

### DIFF
--- a/public/assets/tools/sprite.svg
+++ b/public/assets/tools/sprite.svg
@@ -1,4 +1,4 @@
-<svg width="0" height="0" class="hidden">
+<svg width="0" height="0">
   <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="discussions">
     <rect width="32" height="32" rx="4" fill="url(#paint0_linear_1025_7198)"></rect>
     <path d="M6.3999 9.99998C6.3999 8.67449 7.47442 7.59998 8.7999 7.59998H17.1999C18.5254 7.59998 19.5999 8.67449 19.5999 9.99998V14.8C19.5999 16.1255 18.5254 17.2 17.1999 17.2H14.7999L11.1999 20.8V17.2H8.7999C7.47442 17.2 6.3999 16.1255 6.3999 14.8V9.99998Z" fill="white"></path>

--- a/src/lib/components/InlineSvg.svelte
+++ b/src/lib/components/InlineSvg.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
   import { getPublicPath } from "lib/utils/paths";
+  import { fetchSvgContents } from "lib/utils/svg";
   import { onMount } from "svelte";
-
 
   export let src: string;
 
   let svgHtml: string;
   onMount(async () => {
-    const response = await fetch(getPublicPath(src));
-    svgHtml = await response.text();
+    svgHtml = await fetchSvgContents(getPublicPath(src));
   });
 </script>
 

--- a/src/lib/components/LinksMenu.module.scss
+++ b/src/lib/components/LinksMenu.module.scss
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   gap: 32px;
+  flex: 0 0 auto;
 
   :global(.navLink) {
     position: relative;

--- a/src/lib/components/ToolMenu.module.scss
+++ b/src/lib/components/ToolMenu.module.scss
@@ -99,6 +99,7 @@
 
   a {
     line-height: 22px;
+    font: inherit;
   }
 
   &:global(.navButton) {

--- a/src/lib/utils/svg.ts
+++ b/src/lib/utils/svg.ts
@@ -1,0 +1,17 @@
+const localCache: {[key: string]: string} = {};
+
+/**
+ * Fetch the content of svg files as text
+ * @note It will cache locally (in memory) the response for the same `src`
+ * @param src Source path
+ * @returns Svg file content
+ */
+export const fetchSvgContents = (src: string) => {
+  if (localCache[src]) {
+    return Promise.resolve(localCache[src]);
+  }
+
+  return fetch(src, {cache: 'force-cache'})
+    .then(response => response.text())
+    .then(svg => localCache[src] = svg);
+}


### PR DESCRIPTION
This pr fixes a few random issues found while testing the integrations:

- tool selector menu: svg sprite was not displaying icons because of the "hidden" class
- tool selector menu: needs to cache the sprite svg in memory, otherwise it is downloaded on each menu display
- tool selector menu: fix font issue for CTA buttons

- links menu: fix width constraint