### PR TITLE
PROD-3392 - order tools groups on mobile

### DIFF
--- a/src/lib/components/tool-selector/ToolMenu.module.scss
+++ b/src/lib/components/tool-selector/ToolMenu.module.scss
@@ -74,6 +74,7 @@
 
   @include mobile {
     padding: 16px;
+    order: var(--order);
 
     &.hasCtas {
       border-top: 1px solid #D4D4D4;

--- a/src/lib/components/tool-selector/ToolMenu.svelte
+++ b/src/lib/components/tool-selector/ToolMenu.svelte
@@ -24,7 +24,10 @@
 
       <div class={styles.toolGroups}>
         {#each section.children as group}
-          <div class={classnames(styles.toolGroup, hasCtas(group) && styles.hasCtas)}>
+          <div
+            class={classnames(styles.toolGroup, hasCtas(group) && styles.hasCtas)}
+            style:--order={group.groupOrder ?? ''}
+          >
             {#if group.label}
               <div class={styles.toolGroupTitle}>
                 {group.label}

--- a/src/lib/config/nav-menu/tool-selector-nav-items.ts
+++ b/src/lib/config/nav-menu/tool-selector-nav-items.ts
@@ -42,6 +42,7 @@ export const toolSelectorNavItems = {
             children: [
                 {
                     label:"Learn",
+                    groupOrder: 1,
                     children: [
                         {
                             label: "Topcoder Academy",
@@ -65,6 +66,7 @@ export const toolSelectorNavItems = {
                 },
                 {
                     label:"Compete",
+                    groupOrder: 3,
                     children: [
                         {
                             label: "Marathon Matches",
@@ -88,6 +90,7 @@ export const toolSelectorNavItems = {
                 },
                 {
                     label:"Earn",
+                    groupOrder: 2,
                     children: [
                         {
                             label: "Challenges",
@@ -117,6 +120,7 @@ export const toolSelectorNavItems = {
                 },
                 {
                     label:"Connect",
+                    groupOrder: 4,
                     children: [
                         {
                             label:"Forums",

--- a/src/lib/functions/nav-menu-item.model.ts
+++ b/src/lib/functions/nav-menu-item.model.ts
@@ -14,4 +14,7 @@ export interface NavMenuItem {
 
     // path used when user is authenticated
     authenticatedPath?: string
+
+    // for tools groups ordering
+    groupOrder?: number
 }


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-3392

On mobile, adds a defined order (via flex order) for the grouped tools under talent.
![image](https://user-images.githubusercontent.com/2527433/207590562-58b7c058-89f8-4b2f-85e0-9f48de350931.png)
