### PR TITLE
PROD-3391 - mobile nav - remove sub menus for tool navs

### DIFF
--- a/src/lib/components/Accordion.svelte
+++ b/src/lib/components/Accordion.svelte
@@ -41,9 +41,11 @@
           >
             {item.label}
           </a>
-          <span class={styles.itemTrigger} on:click={() => toggleItem(item)} on:keydown={() => {}}>
-            <img src={iconUrl} alt="^" />
-          </span>
+          {#if item.children?.length}
+            <span class={styles.itemTrigger} on:click={() => toggleItem(item)} on:keydown={() => {}}>
+              <img src={iconUrl} alt="^" />
+            </span>
+          {/if}
         </div>
       {:else}
         <a class={styles.navButton} href={navUrl(item)}>

--- a/src/lib/functions/marketing-navigation.provider.ts
+++ b/src/lib/functions/marketing-navigation.provider.ts
@@ -9,6 +9,6 @@ export function getMainNavItems(isAuthenticated: boolean): NavMenuItem[] {
   return activateAuthenticatedRoutes(isAuthenticated, menu);
 }
 
-export function getActiveRoute(index?: number): NavMenuItem[] {
-  return getActiveRouteUtil(navMenu, index);
+export function getActiveRoute(navItems: NavMenuItem[], index?: number): NavMenuItem[] {
+  return getActiveRouteUtil(navItems, index);
 }

--- a/src/lib/marketing-navigation/MarketingNavigation.svelte
+++ b/src/lib/marketing-navigation/MarketingNavigation.svelte
@@ -21,7 +21,8 @@
   let menuItems: NavMenuItem[];
   $: menuItems = getMainNavItems(isAuthenticated)
 
-  const activeRoute: NavMenuItem[] = getActiveRoute()
+  let activeRoute: NavMenuItem[] = [];
+  $: activeRoute = getActiveRoute(menuItems)
   const [primaryRoute, secondaryRoute, tertiaryRoute] = activeRoute
 
   onMount(checkAndLoadFonts)
@@ -29,6 +30,7 @@
 
 <div class="tc-universal-nav-wrap">
   <NavigationBar
+    activeRoutePath={activeRoute}
     activeRoute={primaryRoute}
     style='primary'
     menuItems={menuItems}

--- a/src/lib/marketing-navigation/components/NavigationBar.svelte
+++ b/src/lib/marketing-navigation/components/NavigationBar.svelte
@@ -7,6 +7,7 @@
 
     export let style: 'primary'|'secondary'|'tertiary';
     export let menuItems: NavMenuItem[] = [];
+    export let activeRoutePath: NavMenuItem[] = [];
     export let activeRoute: NavMenuItem;
     export let isMobile: boolean = false;
 
@@ -17,7 +18,10 @@
 
 <TopNavbar style={style} minLogoVersion={isMobile}>
   {#if isMobile}
-    <MobileNavigation />
+    <MobileNavigation
+      menuItems={menuItems}
+      activeRoutes={activeRoutePath}
+    />
   {:else}
     <LinksMenu
         menuItems={menuItems}

--- a/src/lib/mobile-navigation/MobileNavigation.svelte
+++ b/src/lib/mobile-navigation/MobileNavigation.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { NavMenuItem } from 'lib/functions/nav-menu-item.model';
-  import { getActiveRoute, getMainNavItems } from 'lib/functions/marketing-navigation.provider'
   import MobileMenu from 'lib/components/MobileMenu.svelte';
   import Accordion from 'lib/components/Accordion.svelte';
   import { getPublicPath, navUrl } from 'lib/utils/paths';
@@ -8,8 +7,8 @@
 
   import styles from './MobileNavigation.module.scss';
 
-  const menuItems = getMainNavItems()
-  const activeRoutes: NavMenuItem[] = getActiveRoute()
+  export let menuItems: NavMenuItem[];
+  export let activeRoutes: NavMenuItem[] = [];
   const toggleMenuIcon = getPublicPath(`/assets/icon-menu.svg`);
 
   let menuIsVisible = false;

--- a/src/lib/tool-navigation/ToolNavigation.svelte
+++ b/src/lib/tool-navigation/ToolNavigation.svelte
@@ -55,7 +55,9 @@
 
 <TopNavbar minLogoVersion class={styles.navbar} style="primary">
   {#if $isMobile}
-    <MobileNavigation />
+    <MobileNavigation
+      menuItems={menuItems}
+    />
   {:else}
     <LinksMenu
       menuItems={menuItems}

--- a/src/lib/utils/routes.ts
+++ b/src/lib/utils/routes.ts
@@ -65,8 +65,8 @@ export const matchRoutes = (navMenu: NavMenuItem, path: string): NavMenuItem[] =
  * @param trailLevel The trail level of the active route to return
  * @returns
  */
-export function getActiveRoute(navMenu: NavMenuItem, trailLevel?: number): NavMenuItem[] {
+export function getActiveRoute(navMenuItems: NavMenuItem[], trailLevel?: number): NavMenuItem[] {
   const locationHref = `${location.pathname}`
-  const activeRouteTrail = [].concat(matchRoutes(navMenu, locationHref))
+  const activeRouteTrail = [].concat(matchRoutes({children: navMenuItems} as NavMenuItem, locationHref))
   return typeof trailLevel === 'number' ? activeRouteTrail?.slice(trailLevel, 1) : activeRouteTrail
 }


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-3391

Update mobile navigation to receive the menu items from the main navigation component (either tool or marketing).
Hides the sub nav marketing items on mobile for the tool navigation.

![image](https://user-images.githubusercontent.com/2527433/207705336-23e92853-910c-4e4d-b32a-634e8495661b.png)
