### PR TITLE
Switch nav type to marketing for articles -> dev

### DIFF
--- a/src/lib/config/nav-menu/marketing-nav-items.ts
+++ b/src/lib/config/nav-menu/marketing-nav-items.ts
@@ -59,7 +59,10 @@ export const marketingNavItems = {
                     ...navItems.learn,
                     children: [
                         navItems.topcoderAcademyApp,
-                        navItems.articles,
+                        {
+                          ...navItems.articles,
+                          url: `${navItems.articles.url}?navTool=marketing`
+                        },
                     ]
                 },
                 {


### PR DESCRIPTION
Switches the nav type to marketing when accessing articles from the marketing>talent>learn>Articles.