### PR TITLE
Fix routeMatch method - ignore search query/hash strings -> dev

### DIFF
--- a/src/lib/utils/routes.ts
+++ b/src/lib/utils/routes.ts
@@ -1,9 +1,12 @@
 import type { NavMenuItem } from 'lib/functions/nav-menu-item.model';
 import { escapeRegExp } from "./regex";
 
-const routeMatchesUrl = (url: string, route: NavMenuItem): boolean => (
-  !!url.match(new RegExp(`^${escapeRegExp(route.url)}\/?(\\?|#|$)`, 'i'))
-)
+const routeMatchesUrl = (url: string, route: NavMenuItem): boolean => {
+  const urlObj = new URL(route.url);
+  const routeUrl = `${urlObj.origin}${urlObj.pathname}`;
+
+  return !!url.match(new RegExp(`^${escapeRegExp(routeUrl)}\/?(\\?|#|$)`, 'i'));
+}
 
 /**
  * Parses the passed nav menu items and


### PR DESCRIPTION
Fixes the method that matches current url to nav items. It now ignores the current page url's query params &  hash strings. 

The issue:
- go to https://qa-community-app.topcoder-dev.com/thrive?navTool=marketing
- talent/learn/articles navigation item should be highlighted, but it is not
