### PR TITLE
PROD-4020 - update tool's menu review slider behavior -> dev

### DIFF
--- a/src/lib/tool-navigation/ToolNavigation.module.scss
+++ b/src/lib/tool-navigation/ToolNavigation.module.scss
@@ -1,43 +1,16 @@
 @import 'lib/styles/fonts.scss';
 
-.togglerSeparator {
+.primaryMenu {
   position: relative;
-  background: #767676;
-  width: 2px;
-  height: 60px;
-  margin: -18px 0;
-  margin-left: calc(-1 * var(--margin-left, 180px));
-  z-index: 1;
-  transition: 0.2s ease-in-out;
-
-  &.toggled {
-    margin-left: 35px;
-
-    .toggleBtn svg {
-      transform: rotateZ(180deg);
-    }
+  > * {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    transform: translateY(-50%);
   }
-}
 
-.toggleBtn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 25px;
-  height: 25px;
-  border: 1px solid #767676;
-  border-radius: 25px;
-  background: #2A2A2A;
-
-  transform: translate(-50%, -50%);
-  position: absolute;
-  top: 50%;
-  left: 50%;
-
-  cursor: pointer;
-
-  svg {
-    transition: 0.2s ease-in-out;
+  &:not(.visible) > * {
+    pointer-events: none;
   }
 }
 

--- a/src/lib/tool-navigation/ToolNavigation.svelte
+++ b/src/lib/tool-navigation/ToolNavigation.svelte
@@ -16,6 +16,7 @@
   import { useSessionStorage } from 'lib/utils/use-storage';
 
   import styles from './ToolNavigation.module.scss';
+  import ToolNavSeparator from './tool-nav-separator/ToolNavSeparator.svelte';
 
   const ctx = getAppContext()
   $: ({toolConfig, navigationHandler, auth} = $ctx)
@@ -34,7 +35,7 @@
   }
 
   let linksMenuEl: HTMLElement;
-  let mainMenuWidth = useSessionStorage<Number>('mm-width', 157);
+  let mainMenuWidth = useSessionStorage<number>('mm-width', 157);
   let mainMenuVisible = false;
 
   function toggleMainMenu() {
@@ -59,29 +60,19 @@
       menuItems={menuItems}
     />
   {:else}
-    <LinksMenu
-      menuItems={menuItems}
-      bind:ref={linksMenuEl}
-      style='primary'
-    />
-
-    <div
-      class={classnames(styles.togglerSeparator, mainMenuVisible && styles.toggled)}
-      style="--margin-left: {$mainMenuWidth}px"
-    >
-      <span class={styles.toggleBtn} on:click={toggleMainMenu} on:keydown={toggleMainMenu}>
-        <svg width="5" height="9" viewBox="0 0 5 9" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path fill-rule="evenodd" clip-rule="evenodd" d="M0.334413
-            8.26569C0.0219931 7.95327 0.0219931 7.44673 0.334413 7.13432L2.96873
-            4.5L0.334412 1.86569C0.0219928 1.55327 0.0219928 1.04673 0.334412
-            0.734315C0.646832 0.421895 1.15336 0.421895 1.46578 0.734315L4.66578
-            3.93431C4.9782 4.24673 4.9782 4.75327 4.66578 5.06569L1.46578
-            8.26569C1.15336 8.57811 0.646832 8.5781 0.334413 8.26569Z"
-            fill="white"
-          />
-        </svg>
-      </span>
+    <div class={classnames(styles.primaryMenu, mainMenuVisible && styles.visible)}>
+      <LinksMenu
+        menuItems={menuItems}
+        bind:ref={linksMenuEl}
+        style='primary'
+      />
     </div>
+
+    <ToolNavSeparator
+      offsetLeft={$mainMenuWidth}
+      isToggled={mainMenuVisible}
+      onClick={toggleMainMenu}
+    />
 
     <div class={styles.toolNavWrap}>
       <a href={toolConfig.root} class={styles.toolName} on:click={handleNavigation}>

--- a/src/lib/tool-navigation/tool-nav-separator/ToolNavSeparator.module.scss
+++ b/src/lib/tool-navigation/tool-nav-separator/ToolNavSeparator.module.scss
@@ -1,0 +1,40 @@
+.togglerSeparator {
+  position: relative;
+  background: #767676;
+  width: 2px;
+  height: 60px;
+  margin: -18px 0;
+  margin-left: 0;
+  z-index: 1;
+  transition: 0.2s ease-in-out;
+
+  &.toggled {
+    margin-left: calc(35px + var(--margin-left, 180px));
+
+    .toggleBtn svg {
+      transform: rotateZ(180deg);
+    }
+  }
+}
+
+.toggleBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 25px;
+  height: 25px;
+  border: 1px solid #767676;
+  border-radius: 25px;
+  background: #2A2A2A;
+
+  transform: translate(-50%, -50%);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+
+  cursor: pointer;
+
+  svg {
+    transition: 0.2s ease-in-out;
+  }
+}

--- a/src/lib/tool-navigation/tool-nav-separator/ToolNavSeparator.svelte
+++ b/src/lib/tool-navigation/tool-nav-separator/ToolNavSeparator.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import { classnames } from "lib/utils/classnames";
+    import styles from './ToolNavSeparator.module.scss';
+
+    export let isToggled: boolean = false;
+    export let offsetLeft: number = 0;
+    export let onClick: () => void;
+</script>
+
+<div
+  class={classnames(styles.togglerSeparator, isToggled && styles.toggled)}
+  style="--margin-left: {offsetLeft}px"
+>
+  <span class={styles.toggleBtn} on:click={onClick} on:keydown={() => {}}>
+    <svg width="5" height="9" viewBox="0 0 5 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M0.334413
+        8.26569C0.0219931 7.95327 0.0219931 7.44673 0.334413 7.13432L2.96873
+        4.5L0.334412 1.86569C0.0219928 1.55327 0.0219928 1.04673 0.334412
+        0.734315C0.646832 0.421895 1.15336 0.421895 1.46578 0.734315L4.66578
+        3.93431C4.9782 4.24673 4.9782 4.75327 4.66578 5.06569L1.46578
+        8.26569C1.15336 8.57811 0.646832 8.5781 0.334413 8.26569Z"
+        fill="white"
+      />
+    </svg>
+  </span>
+</div>


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-4020

Updates the behavior of the main menu reveal slider that's under the tool navigation:
 - slider defaults to collapsed position (so on initialization we don't see the slider animation anymore)
 - when slider is collapsed, the clicks for main menu are ignored (pointer-events: none)