### PR TITLE
Add CORS for learn.topcoder subdomain

### DIFF
--- a/iac/deploy-stack.sh
+++ b/iac/deploy-stack.sh
@@ -35,6 +35,7 @@ echo "Template: $template"
 echo "Stage: $stage"
 echo "Stack name: $stackName"
 echo "Domain: $DOMAIN"
+echo "AWS Profile: $AWS_PROFILE"
 
 # approve the deployment
 silent=$2
@@ -56,6 +57,7 @@ echo "Deploy (i.e. create or update) the stack w/the params"
 aws cloudformation deploy \
     --stack-name $stackName \
     --template-file $template \
+    --profile $AWS_PROFILE \
     --parameter-overrides \
         Stage=$stage \
         Domain=$DOMAIN

--- a/iac/uni-nav.deploy.yml
+++ b/iac/uni-nav.deploy.yml
@@ -169,6 +169,9 @@ Resources:
                             # Platform UI Prod & Dev
                             - !Sub https://platform-ui.${Domain}
 
+                            # Learn subromain Prod & Dev
+                            - !Sub https://learn.${Domain}
+
                             # Platform UI Local
                             - !If
                                 - IsProd

--- a/iac/uni-nav.deploy.yml
+++ b/iac/uni-nav.deploy.yml
@@ -169,8 +169,8 @@ Resources:
                             # Platform UI Prod & Dev
                             - !Sub https://platform-ui.${Domain}
 
-                            # Learn subromain Prod & Dev
-                            - !Sub https://learn.${Domain}
+                            # Topcoder Academy subdomain Prod & Dev
+                            - !Sub https://academy.${Domain}
 
                             # Platform UI Local
                             - !If


### PR DESCRIPTION
Adds `learn.topcoder.com` to CORS policy.

NOTE: needs to be deployed using [iac/deploy-stack.sh](/topcoder-platform/universal-navigation/tree/dev/iac/README.md)