### PR TITLE
MP-45 update cors domains -> dev

### DIFF
--- a/iac/uni-nav.deploy.yml
+++ b/iac/uni-nav.deploy.yml
@@ -174,6 +174,8 @@ Resources:
                             - !Sub https://work.${Domain}
                             - !Sub https://gamification-admin.${Domain}
                             - !Sub https://devcenter.${Domain}
+                            - !Sub https://profiles.${Domain}
+                            - !Sub https://talent-search.${Domain}
 
                             # Platform UI Local
                             - !If
@@ -204,6 +206,18 @@ Resources:
                                 - IsProd
                                 - !Ref AWS::NoValue
                                 - !Sub 'https://gamification-admin.local.${Domain}'
+
+                            # Profiles Local
+                            - !If
+                                - IsProd
+                                - !Ref AWS::NoValue
+                                - !Sub 'https://profiles.local.${Domain}'
+
+                            # Talent search Local
+                            - !If
+                                - IsProd
+                                - !Ref AWS::NoValue
+                                - !Sub 'https://talent-search.local.${Domain}'
 
                             # PTC Prod & QA
                             - !If

--- a/src/lib/config/env-vars.ts
+++ b/src/lib/config/env-vars.ts
@@ -1,0 +1,10 @@
+// if there's no value for the specified config key, throw an error;
+// otherwise, return the value for the specified key.
+export function getEnvValue<T>(viteKey: string, defaultValue?: string): T {
+  if (!Object.prototype.hasOwnProperty.call(import.meta.env, viteKey) && defaultValue === undefined) {
+      throw new Error(`Config variable '${viteKey}' is missing from your .env file!`)
+  }
+
+  const viteValue: string = import.meta.env[viteKey] ?? defaultValue
+  return viteValue as unknown as T
+}

--- a/src/lib/config/hosts.ts
+++ b/src/lib/config/hosts.ts
@@ -1,0 +1,42 @@
+import { getEnvValue } from "./env-vars"
+
+export type HOST_ENV_TYPE = 'dev' | 'prod' | 'qa'
+
+export const HOST_ENV = getEnvValue<HOST_ENV_TYPE>('VITE_APP_HOST_ENV')
+
+export const TC_DOMAIN: string = {
+  dev: 'topcoder-dev.com',
+  prod: 'topcoder.com',
+  qa: 'topcoder-qa.com',
+}[HOST_ENV] || 'topcoder.com'
+
+
+export const WP_HOST_URL: string = `https://www.${TC_DOMAIN}`;
+export const CHALLENGE_HOST: string = `https://www.${TC_DOMAIN}`;
+export const COMMUNITY_HOST: string = `https://www.${TC_DOMAIN}`;
+export const PACTS_HOST: string = `https://community.${TC_DOMAIN}`;
+export const FORUM_HOST: string = `https://vanilla.${TC_DOMAIN}`;
+export const ONLINE_REVIEW_HOST: string = `https://software.${TC_DOMAIN}`;
+export const TCACADEMY_HOST: string = `https://academy.${TC_DOMAIN}`;
+export const DEV_CENTER_HOST: string = `https://devcenter.${TC_DOMAIN}`;
+export const SELF_SERVICE_HOST: string = `https://work.${TC_DOMAIN}`;
+export const TC_API_V5_HOST: string = `https://api.${TC_DOMAIN}/v5`;
+export const CONNECT_HOST: string = `https://connect.${TC_DOMAIN}`;
+export const WORK_MANAGER_HOST: string = `https://challenges.${TC_DOMAIN}`;
+
+console.table({
+  HOST_ENV,
+  TC_DOMAIN,
+  WP_HOST_URL,
+  CHALLENGE_HOST,
+  COMMUNITY_HOST,
+  PACTS_HOST,
+  FORUM_HOST,
+  ONLINE_REVIEW_HOST,
+  TCACADEMY_HOST,
+  DEV_CENTER_HOST,
+  SELF_SERVICE_HOST,
+  TC_API_V5_HOST,
+  CONNECT_HOST,
+  WORK_MANAGER_HOST,
+})

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -2,29 +2,9 @@
 // use `import.meta.env` to access env variables
 // use VITE_ prefix in .env to expose variable to the app
 
-// if no value for the specified config key exists,
-// throw an error;
-// otherwise, return the value for the specified key.
-function getEnvValue(viteKey: string, defaultValue?: string): string {
-    if (!Object.prototype.hasOwnProperty.call(import.meta.env, viteKey) && defaultValue === undefined) {
-        throw new Error(`Config variable '${viteKey}' is missing from your .env file!`)
-    }
+import { getEnvValue } from "./env-vars"
 
-    const viteValue: string = import.meta.env[viteKey] ?? defaultValue
-    return viteValue
-}
-
-export const WP_HOST_URL: string = getEnvValue('VITE_WP_HOST_URL')
-export const CHALLENGE_HOST: string = getEnvValue('VITE_CHALLENGE_HOST')
-export const COMMUNITY_HOST: string = getEnvValue('VITE_COMMUNITY_HOST')
-export const PACTS_HOST: string = getEnvValue('VITE_PACTS_HOST')
-export const FORUM_HOST: string = getEnvValue('VITE_FORUM_HOST')
-export const ONLINE_REVIEW_HOST: string = getEnvValue('VITE_ONLINE_REVIEW_HOST')
-export const TCACADEMY_HOST: string = getEnvValue('VITE_TCACADEMY_HOST')
-export const DEV_CENTER_HOST: string = getEnvValue('VITE_DEV_CENTER_HOST')
-export const SELF_SERVICE_HOST: string = getEnvValue('VITE_SELF_SERVICE_HOST')
-export const TC_API_V5_HOST: string = getEnvValue('VITE_TC_API_V5_HOST')
-export const CONNECT_HOST: string = getEnvValue('VITE_CONNECT_HOST')
-export const WORK_MANAGER_HOST: string = getEnvValue('VITE_WORK_MANAGER_HOST')
 export const SPRIG_ID: string = getEnvValue('VITE_SPRIG_ID', '')
 export const CHAMELEON_KEY_ID: string = getEnvValue('VITE_CHAMELEON_KEY_ID', '')
+
+export * from './hosts'

--- a/types/src/lib/config/env-vars.d.ts
+++ b/types/src/lib/config/env-vars.d.ts
@@ -1,0 +1,1 @@
+export declare function getEnvValue<T>(viteKey: string, defaultValue?: string): T;

--- a/types/src/lib/config/hosts.d.ts
+++ b/types/src/lib/config/hosts.d.ts
@@ -1,0 +1,15 @@
+export declare type HOST_ENV_TYPE = 'dev' | 'prod' | 'qa';
+export declare const HOST_ENV: HOST_ENV_TYPE;
+export declare const TC_DOMAIN: string;
+export declare const WP_HOST_URL: string;
+export declare const CHALLENGE_HOST: string;
+export declare const COMMUNITY_HOST: string;
+export declare const PACTS_HOST: string;
+export declare const FORUM_HOST: string;
+export declare const ONLINE_REVIEW_HOST: string;
+export declare const TCACADEMY_HOST: string;
+export declare const DEV_CENTER_HOST: string;
+export declare const SELF_SERVICE_HOST: string;
+export declare const TC_API_V5_HOST: string;
+export declare const CONNECT_HOST: string;
+export declare const WORK_MANAGER_HOST: string;

--- a/types/src/lib/config/index.d.ts
+++ b/types/src/lib/config/index.d.ts
@@ -1,14 +1,3 @@
-export declare const WP_HOST_URL: string;
-export declare const CHALLENGE_HOST: string;
-export declare const COMMUNITY_HOST: string;
-export declare const PACTS_HOST: string;
-export declare const FORUM_HOST: string;
-export declare const ONLINE_REVIEW_HOST: string;
-export declare const TCACADEMY_HOST: string;
-export declare const DEV_CENTER_HOST: string;
-export declare const SELF_SERVICE_HOST: string;
-export declare const TC_API_V5_HOST: string;
-export declare const CONNECT_HOST: string;
-export declare const WORK_MANAGER_HOST: string;
 export declare const SPRIG_ID: string;
 export declare const CHAMELEON_KEY_ID: string;
+export * from './hosts';

--- a/uni-nav.env.prod
+++ b/uni-nav.env.prod
@@ -1,15 +1,4 @@
 # environment variables for the prod env
-VITE_WP_HOST_URL=https://www.topcoder.com
-VITE_CHALLENGE_HOST=https://www.topcoder.com
-VITE_COMMUNITY_HOST=https://www.topcoder.com
-VITE_PACTS_HOST=https://community.topcoder.com
-VITE_FORUM_HOST=https://discussions.topcoder.com
-VITE_ONLINE_REVIEW_HOST=https://software.topcoder.com
-VITE_TC_API_V5_HOST=https://api.topcoder.com/v5
+VITE_APP_HOST_ENV=prod
 VITE_SPRIG_ID='a-IZBZ6-r7bU'
 VITE_CHAMELEON_KEY_ID=SAcpvabiB6Vsb9yZm32REVpDemzhOjyY6iznnOufjNlqyk-1DPhtq-A61ZuE9U5MrO1WGx
-VITE_WORK_MANAGER_HOST=https://challenges.topcoder.com
-VITE_CONNECT_HOST=https://connect.topcoder.com
-VITE_TCACADEMY_HOST=https://academy.topcoder.com
-VITE_DEV_CENTER_HOST=https://devcenter.topcoder.com
-VITE_SELF_SERVICE_HOST=https://work.topcoder.com

--- a/uni-nav.env.qa
+++ b/uni-nav.env.qa
@@ -1,4 +1,4 @@
-# environment variables for the dev env
-VITE_APP_HOST_ENV=dev
+# environment variables for the qa env
+VITE_APP_HOST_ENV=qa
 VITE_SPRIG_ID='bUcousVQ0-yF'
 VITE_CHAMELEON_KEY_ID=SAcpvabiB6Vsb9yZm32REVpDemzhOjyY6iznnOufjNlqyk-1DPhtq-A61ZuE9U5MrO1WGx


### PR DESCRIPTION
Related ticket:
 https://topcoder.atlassian.net/browse/MP-45

- Adds CORS headers for profiles & talent-search sub-domains
- moves host urls out of `.env` files and into config/hosts, and computes the host urls based on the HOST_ENV variable
- adds support for QA env

Note:

==================
- this has CORS updates, so we have to deploy the [IAC Stack](https://github.com/topcoder-platform/universal-navigation/tree/dev/iac)
- the updated uni-nav.env.dev, uni-nav.env.qa and uni-nav.env.prod files need to be copied in their respective s3 buckets before merging this PR, so when uninav builds, the correct env files are in place: `s3://tc-uninav-${LOGICAL_ENV}/securitymanager/uni-nav.env.${LOGICAL_ENV}`