### PR TITLE
MP-78 - fix progress bar for safari

### DIFF
--- a/src/lib/components/user-area/ProgressCicle.svelte
+++ b/src/lib/components/user-area/ProgressCicle.svelte
@@ -4,7 +4,8 @@
   // 94.247 is the circumference of the svg circle
   const c = 94.247;
 
-  $: offset = (-1 * progress) * c / 100;
+  // double the circle circumference minus the progress length
+  $: offset = c * 2 - (progress * c / 100);
 
 </script>
 

--- a/src/lib/components/user-area/UserAvatar.module.scss
+++ b/src/lib/components/user-area/UserAvatar.module.scss
@@ -10,12 +10,26 @@
   cursor: pointer;
   z-index: 1;
 
+  &:after {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #0c0c0c;
+    border-radius: inherit;
+  }
+
   img {
     object-fit: cover;
     display: block;
     width: 100%;
     height: 100%;
     border-radius: inherit;
+    position: relative;
+    z-index: 1;
   }
 
   > span {


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/MP-78

Fixes the user profile progress bar on safari: safari doesn't support negative values for svg `stroke-dashoffset` so had to come with a workaround that seems to work well.