### PR TITLE
MP-188 - dismiss profile nudges on certain domains -> dev

### DIFF
--- a/src/lib/components/user-area/UserArea.svelte
+++ b/src/lib/components/user-area/UserArea.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { getAppContext } from 'lib/app-context';
   import { checkUserAppRole, fetchUserProfile } from 'lib/functions/user-profile.provider';
-  import { fetchUserProfileCompletedness } from 'lib/functions/profile-completeness';
+  import { fetchUserProfileCompletedness, dismissNudgesBasedOnHost } from 'lib/functions/profile-nudges';
   import { AUTH_USER_ROLE } from 'lib/config/auth';
 
   import ToolSelector from '../tool-selector/ToolSelector.svelte';
@@ -30,7 +30,7 @@
 
   async function fetchProfileDetails() {
     // do nothing if user is not authenticated or has customer role
-    if (!user || checkUserAppRole(AUTH_USER_ROLE.customer) || debounce === user.handle) {
+    if (dismissNudgesBasedOnHost() || !user || checkUserAppRole(AUTH_USER_ROLE.customer) || debounce === user.handle) {
       return;
     }
 

--- a/src/lib/config/hosts.ts
+++ b/src/lib/config/hosts.ts
@@ -36,3 +36,5 @@ export const TC_API_V5_HOST: string = `https://api.${TC_DOMAIN}/v5`;
 export const CONNECT_HOST: string = `https://connect.${TC_DOMAIN}`;
 export const WORK_MANAGER_HOST: string = `https://challenges.${TC_DOMAIN}`;
 export const PROFILE_HOST: string = `https://profiles.${TC_DOMAIN}`;
+export const ONBOARDING_HOST: string = `https://onboarding.${TC_DOMAIN}`;
+export const TALENT_SEARCH_HOST: string = `https://talent-search.${TC_DOMAIN}`;

--- a/src/lib/config/profile-toasts.config.ts
+++ b/src/lib/config/profile-toasts.config.ts
@@ -1,4 +1,18 @@
-import { PROFILE_HOST } from "lib/config/hosts"
+import {
+  CONNECT_HOST,
+  ONBOARDING_HOST,
+  PROFILE_HOST,
+  TALENT_SEARCH_HOST,
+  WORK_MANAGER_HOST,
+} from "lib/config/hosts";
+
+export const NUDGES_DISABLED_HOSTS = [
+  CONNECT_HOST,
+  ONBOARDING_HOST,
+  PROFILE_HOST,
+  TALENT_SEARCH_HOST,
+  WORK_MANAGER_HOST,
+];
 
 export interface ToastType {
   theme: 'bio' | 'education' | 'gigAvailability' | 'profilePicture' | 'skills' | 'verified' | 'workHistory'

--- a/src/lib/functions/profile-nudges.ts
+++ b/src/lib/functions/profile-nudges.ts
@@ -1,6 +1,19 @@
 import { TC_API_V5_HOST } from "lib/config";
-import { getRequestAuthHeaders } from "./auth-jwt";
 import type { AuthUser } from "lib/app-context";
+import { NUDGES_DISABLED_HOSTS } from "lib/config/profile-toasts.config";
+
+import { getRequestAuthHeaders } from "./auth-jwt";
+
+/**
+ * Check if we're on a domain that should not show the profile nudges
+ * @returns Boolean
+ */
+export function dismissNudgesBasedOnHost(): boolean {
+  const locationHostname = window?.location.hostname ?? ''
+  return !! NUDGES_DISABLED_HOSTS.find(host => (
+    host.match(new RegExp(`^https?:\/\/${locationHostname}`, 'i'))
+  ));
+}
 
 // store fetched data in a local cache (de-duplicate immediate api calls)
 const localCache = {};

--- a/src/lib/nudge-app/toast-manager.ts
+++ b/src/lib/nudge-app/toast-manager.ts
@@ -1,6 +1,7 @@
 import type { ProfileCompletionData } from 'lib/app-context/profile-completion.model';
-import { checkCookie, getCookieValue, setCookie } from '../utils/cookies';
 import { toastsMeta } from 'lib/config/profile-toasts.config';
+import { checkCookie, getCookieValue, setCookie } from '../utils/cookies';
+import { dismissNudgesBasedOnHost } from '../functions/profile-nudges';
 
 const TOAST_COOKIE = 'uni-toast-shown';
 const TOAST_COOKIE_ACTIVE_PERIOD_DAYS = 7;
@@ -23,7 +24,7 @@ function getLastSeenToast() {
  * @returns
  */
 export const getToast = (completednessData: ProfileCompletionData) => {
-  if (!completednessData || completednessData.completed || isToastDismissed()) {
+  if (dismissNudgesBasedOnHost() || !completednessData || completednessData.completed || isToastDismissed()) {
     return;
   }
 

--- a/types/src/lib/config/hosts.d.ts
+++ b/types/src/lib/config/hosts.d.ts
@@ -15,3 +15,5 @@ export declare const TC_API_V5_HOST: string;
 export declare const CONNECT_HOST: string;
 export declare const WORK_MANAGER_HOST: string;
 export declare const PROFILE_HOST: string;
+export declare const ONBOARDING_HOST: string;
+export declare const TALENT_SEARCH_HOST: string;

--- a/types/src/lib/config/profile-toasts.config.d.ts
+++ b/types/src/lib/config/profile-toasts.config.d.ts
@@ -1,3 +1,4 @@
+export declare const NUDGES_DISABLED_HOSTS: string[];
 export interface ToastType {
     theme: 'bio' | 'education' | 'gigAvailability' | 'profilePicture' | 'skills' | 'verified' | 'workHistory';
     icon: string;

--- a/types/src/lib/functions/profile-nudges.d.ts
+++ b/types/src/lib/functions/profile-nudges.d.ts
@@ -1,4 +1,9 @@
 import type { AuthUser } from "lib/app-context";
+/**
+ * Check if we're on a domain that should not show the profile nudges
+ * @returns Boolean
+ */
+export declare function dismissNudgesBasedOnHost(): boolean;
 export interface ProfileCompletednessResponse {
     handle: string;
     showToast: string;


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/MP-188

Dismisses the profile nudges on certain domains by matching the configured dismissed hosts to the current URL:
- Onboarding (onboarding.topcoder-dev.com)
- Profiles (profiles.topcoder-dev.com)
- Work Manager (challenges.topcoder-dev.com)
- Talent search (talent-search.topcoder-dev.com)
- Connect (connect.topcoder-dev.com)