### PR TITLE
Fetch user completeness data on all domains, but not for customer users

### DIFF
--- a/src/lib/components/user-area/UserArea.svelte
+++ b/src/lib/components/user-area/UserArea.svelte
@@ -30,7 +30,7 @@
 
   async function fetchProfileDetails() {
     // do nothing if user is not authenticated or has customer role
-    if (dismissNudgesBasedOnHost() || !user || checkUserAppRole(AUTH_USER_ROLE.customer) || debounce === user.handle) {
+    if (!user || checkUserAppRole(AUTH_USER_ROLE.customer) || debounce === user.handle) {
       return;
     }
 
@@ -80,7 +80,7 @@
       <UserAvatar
         user={user}
         onSignOut={onSignOut}
-        profileCompletionPerc={profileCompletionData?.percentComplete ?? 0}
+        profileCompletionPerc={profileCompletionData?.percentComplete}
       >
         {#if profileCompletionData}
         <Completedness />

--- a/src/lib/components/user-area/UserMenu.svelte
+++ b/src/lib/components/user-area/UserMenu.svelte
@@ -2,12 +2,11 @@
   import type { AuthUser } from "lib/app-context";
   import { ACCOUNT_SETTINGS_HOST, PROFILE_HOST } from "lib/config";
   import { routeMatchesUrl } from "lib/utils/routes";
-  import { dismissNudgesBasedOnHost } from "lib/functions/profile-nudges";
   import styles from "./UserMenu.module.scss";
 
   export let user: AuthUser;
   export let onSignOut: () => void;
-  export let profileCompletionPerc: number;
+  export let profileCompletionPerc: number | undefined;
 
   const MY_PROFILE_URL = `${PROFILE_HOST}/${user.handle}`;
   const ACC_SETTINGS_URL = `${ACCOUNT_SETTINGS_HOST}`;
@@ -24,7 +23,7 @@
 
 <div class={styles.userMenu}>
   <ul>
-    <li class:nudge={!dismissNudgesBasedOnHost() && profileCompletionPerc < 100}>
+    <li class:nudge={profileCompletionPerc !== undefined && profileCompletionPerc < 100}>
       <a
         href={MY_PROFILE_URL}
         class:active={isActive(MY_PROFILE_URL)}

--- a/src/lib/config/profile-toasts.config.ts
+++ b/src/lib/config/profile-toasts.config.ts
@@ -7,13 +7,17 @@ import {
   WORK_MANAGER_HOST,
 } from "lib/config/hosts";
 
-export const NUDGES_DISABLED_HOSTS = [
+export const CUSTOMER_HOSTS = [
   CONNECT_HOST,
-  ONBOARDING_HOST,
-  PROFILE_HOST,
   SELF_SERVICE_HOST,
   TALENT_SEARCH_HOST,
   WORK_MANAGER_HOST,
+]
+
+export const NUDGES_DISABLED_HOSTS = [
+  ...CUSTOMER_HOSTS,
+  ONBOARDING_HOST,
+  PROFILE_HOST,
 ];
 
 export interface ToastType {

--- a/src/lib/functions/profile-nudges.ts
+++ b/src/lib/functions/profile-nudges.ts
@@ -10,7 +10,7 @@ import { getRequestAuthHeaders } from "./auth-jwt";
  */
 export function dismissNudgesBasedOnHost(): boolean {
   const locationHostname = window?.location.hostname ?? ''
-  return !! NUDGES_DISABLED_HOSTS.find(host => (
+  return !!NUDGES_DISABLED_HOSTS.find(host => (
     host.match(new RegExp(`^https?:\/\/${locationHostname}`, 'i'))
   ));
 }

--- a/types/src/lib/config/profile-toasts.config.d.ts
+++ b/types/src/lib/config/profile-toasts.config.d.ts
@@ -1,3 +1,4 @@
+export declare const CUSTOMER_HOSTS: string[];
 export declare const NUDGES_DISABLED_HOSTS: string[];
 export interface ToastType {
     theme: 'bio' | 'education' | 'gigAvailability' | 'profilePicture' | 'skills' | 'verified' | 'workHistory';


### PR DESCRIPTION
Related JIRA tickets:
https://topcoder.atlassian.net/browse/MP-323 - Show progress ring around the avatar across all applications
https://topcoder.atlassian.net/browse/MP-328 - Red dot near the Profiles is displayed for Customer account

This PR  fetches the user profile completeness on all domains, but dismisses it for customer users. The toast nudges are now hidden based on app hostname.