### PR TITLE
TAL-69 - Add sales cta buttons for ToolsNavbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
       tcUniNav('init', 'tool-nav', {
         type: 'tool',
         toolName: 'Tool Name',
+        showSalesCta: true,
         onReady() {console.log('tool nav ready')},
         signIn() {console.log('Sign in was called')},
         signUp() {console.log('Sign up was called')},

--- a/src/lib/app-context/app-context.functions.ts
+++ b/src/lib/app-context/app-context.functions.ts
@@ -16,12 +16,17 @@ export const buildContext = (newConfig: Partial<NavigationAppProps>, prevContext
     supportMeta = prevContext.supportMeta,
     integrations = prevContext.integrations,
     fullFooter = prevContext.toolConfig?.fullFooter,
+    showSalesCta = prevContext.toolConfig?.showSalesCta,
     profileCompletionData = prevContext.auth?.profileCompletionData,
   } = {...newConfig, user: undefined}
 
   const hasUserProp = hasOwnProperty(newConfig, 'user') && newConfig['user'] !== 'auto'
-  // user: 'atuo' translates to auth.autoFetchUser: true
-  const autoFetchUser = hasOwnProperty(newConfig, 'user') ? newConfig['user'] === 'auto' : !!prevContext.auth?.autoFetchUser
+
+  // user: 'auto' translates to auth.autoFetchUser: true
+  const autoFetchUser = hasOwnProperty(newConfig, 'user')
+    ? newConfig['user'] === 'auto' : (
+      prevContext.auth?.autoFetchUser === false ? false : true
+    )
 
   return {
     auth: {
@@ -38,6 +43,7 @@ export const buildContext = (newConfig: Partial<NavigationAppProps>, prevContext
       name: toolName,
       root: toolRoot,
       fullFooter,
+      showSalesCta,
     },
     supportMeta,
     integrations,

--- a/src/lib/app-context/tool-config.model.ts
+++ b/src/lib/app-context/tool-config.model.ts
@@ -2,4 +2,5 @@ export interface ToolConfig {
   name: string
   root: string
   fullFooter?: boolean
+  showSalesCta?: boolean
 }

--- a/src/lib/components/LinksMenu.module.scss
+++ b/src/lib/components/LinksMenu.module.scss
@@ -83,5 +83,12 @@
     border-radius: 24px;
 
     padding: 0 16px;
+
+
+    &.cta {
+      background: #137D60;
+      border: #137D60;
+      margin-right: -12px;
+    }
   }
 }

--- a/src/lib/components/LinksMenu.svelte
+++ b/src/lib/components/LinksMenu.svelte
@@ -5,7 +5,7 @@
 
   export let ref: Element | undefined = undefined;
 
-  export let style: "primary" | "secondary" | "tertiary";
+  export let style: "primary" | "secondary" | "tertiary" | 'cta';
   export let menuItems: NavMenuItem[];
   export let activeRoute: NavMenuItem = undefined;
   export let hoveredMenuItem: NavMenuItem = undefined;

--- a/src/lib/components/VerticalSeparator.module.scss
+++ b/src/lib/components/VerticalSeparator.module.scss
@@ -4,6 +4,7 @@
   display: block;
   padding: 0 32px 0 48px;
   margin: -18px 0;
+  pointer-events: none;
   &:before {
     content: "";
     display: block;

--- a/src/lib/config/nav-menu/tool-nav-items.ts
+++ b/src/lib/config/nav-menu/tool-nav-items.ts
@@ -1,5 +1,6 @@
 import type { NavMenuItem } from "../../functions/nav-menu-item.model";
 
+import { allNavItems } from "./all-nav-items.config";
 import { mainNavigationItems } from "./main-navigation.config";
 
 export const toolNavItems: NavMenuItem = {
@@ -7,3 +8,8 @@ export const toolNavItems: NavMenuItem = {
       ...mainNavigationItems,
     ],
 }
+
+export const toolCtaNavItems: NavMenuItem[] = [
+  allNavItems.talkToAnExpert,
+  allNavItems.bookADemo,
+]

--- a/src/lib/functions/tool-navigation.provider.ts
+++ b/src/lib/functions/tool-navigation.provider.ts
@@ -8,3 +8,5 @@ export function getMainNavItems(isAuthenticated: boolean): NavMenuItem[] {
   const menu = JSON.parse(JSON.stringify(navMenu));
   return activateAuthenticatedRoutes(isAuthenticated, menu);
 }
+
+export { toolCtaNavItems } from 'lib/config/nav-menu/tool-nav-items'

--- a/src/lib/tool-navigation/SalesCtaButtons.svelte
+++ b/src/lib/tool-navigation/SalesCtaButtons.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { AUTH_USER_ROLE } from 'lib/config/auth';
+  import { checkUserAppRole } from 'lib/functions/user-profile.provider';
+  import { toolCtaNavItems } from 'lib/functions/tool-navigation.provider'
+  import LinksMenu from 'lib/components/LinksMenu.svelte';
+
+  export let isAuthenticated: boolean;
+</script>
+
+{#if !isAuthenticated || checkUserAppRole(AUTH_USER_ROLE.customer)}
+  <LinksMenu
+    menuItems={toolCtaNavItems}
+    style='cta'
+  />
+{/if}

--- a/src/lib/tool-navigation/ToolNavigation.svelte
+++ b/src/lib/tool-navigation/ToolNavigation.svelte
@@ -18,6 +18,7 @@
 
   import styles from './ToolNavigation.module.scss';
   import ToolNavSeparator from './tool-nav-separator/ToolNavSeparator.svelte';
+  import SalesCtaButtons from './SalesCtaButtons.svelte';
 
   const ctx = getAppContext()
   $: ({toolConfig, navigationHandler, auth} = $ctx)
@@ -88,5 +89,10 @@
     </div>
   {/if}
 
-  <UserArea slot="right" />
+  <svelte:fragment slot="right">
+    {#if !$isMobile && toolConfig.showSalesCta && auth.ready}
+      <SalesCtaButtons isAuthenticated={isAuthenticated} />
+    {/if}
+    <UserArea />
+  </svelte:fragment>
 </TopNavbar>

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ export type NavigationAppProps = {
   toolName?: string,
   toolRoot?: string,
   fullFooter?: boolean,
+  showSalesCta?: boolean,
   handleNavigation?: NavigationHandler
 
   onReady?: () => void

--- a/types/src/lib/app-context/app-context.functions.d.ts
+++ b/types/src/lib/app-context/app-context.functions.d.ts
@@ -16,6 +16,7 @@ export declare const buildContext: (newConfig: Partial<NavigationAppProps>, prev
         name: any;
         root: any;
         fullFooter: any;
+        showSalesCta: any;
     };
     supportMeta: any;
     integrations: any;

--- a/types/src/lib/app-context/tool-config.model.d.ts
+++ b/types/src/lib/app-context/tool-config.model.d.ts
@@ -2,4 +2,5 @@ export interface ToolConfig {
     name: string;
     root: string;
     fullFooter?: boolean;
+    showSalesCta?: boolean;
 }

--- a/types/src/lib/config/nav-menu/tool-nav-items.d.ts
+++ b/types/src/lib/config/nav-menu/tool-nav-items.d.ts
@@ -1,2 +1,3 @@
 import type { NavMenuItem } from "../../functions/nav-menu-item.model";
 export declare const toolNavItems: NavMenuItem;
+export declare const toolCtaNavItems: NavMenuItem[];

--- a/types/src/lib/functions/tool-navigation.provider.d.ts
+++ b/types/src/lib/functions/tool-navigation.provider.d.ts
@@ -1,2 +1,3 @@
 import type { NavMenuItem } from './nav-menu-item.model';
 export declare function getMainNavItems(isAuthenticated: boolean): NavMenuItem[];
+export { toolCtaNavItems } from 'lib/config/nav-menu/tool-nav-items';

--- a/types/src/main.d.ts
+++ b/types/src/main.d.ts
@@ -7,6 +7,7 @@ export declare type NavigationAppProps = {
     toolName?: string;
     toolRoot?: string;
     fullFooter?: boolean;
+    showSalesCta?: boolean;
     handleNavigation?: NavigationHandler;
     onReady?: () => void;
     user?: AuthUser | 'auto';


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TAL-69 - Add sales CTAs to the header in Talent Search app

Adds a config to enable displaying of sales CTA buttons inside the Tools navbar.
A few conditions that have to be met for  this to be displayed:
- configuration flag `showSalesCta` needs to be set to `true`
- user must either be a customer or not logged in at all
- on mobile devices the CTAs are hidden (according to discussions & figma - there's not enough room)

![image](https://github.com/topcoder-platform/universal-navigation/assets/2527433/a9b9fbf5-a4cc-40dd-920e-481e33e4aef1)
