### PR TITLE
Revert "Restore payment app as "PACTS" instead of wallet"

### DIFF
--- a/src/lib/config/hosts.ts
+++ b/src/lib/config/hosts.ts
@@ -27,7 +27,6 @@ export const FORUM_HOST: string = {
   prod: `https://discussions.${TC_DOMAIN}`,
 }[HOST_ENV] || `https://discussions.${TC_DOMAIN}`;
 
-export const PACTS_HOST: string = `https://community.${TC_DOMAIN}`;
 export const ONLINE_REVIEW_HOST: string = `https://software.${TC_DOMAIN}`;
 export const TCACADEMY_HOST: string = `https://academy.${TC_DOMAIN}`;
 export const DEV_CENTER_HOST: string = `https://devcenter.${TC_DOMAIN}`;

--- a/src/lib/config/nav-menu/all-nav-items.config.ts
+++ b/src/lib/config/nav-menu/all-nav-items.config.ts
@@ -8,7 +8,6 @@ import {
     DEV_CENTER_HOST,
     FORUM_HOST,
     ONLINE_REVIEW_HOST,
-    PACTS_HOST,
     SELF_SERVICE_HOST,
     TALENT_SEARCH_HOST,
     TCACADEMY_HOST,
@@ -285,8 +284,8 @@ export const allNavItems: {[key: string]: NavMenuItem} = {
         url: getWordpressUrl('/customer/partners'),
     },
     payments: {
-        label: 'Payments',
-        url: `${PACTS_HOST}/PactsMemberServlet?module=PaymentHistory`,
+        label: 'Wallet',
+        url: WALLETAPP_HOST,
         icon: 'payments',
         description: 'Get paid',
     },

--- a/types/src/lib/config/hosts.d.ts
+++ b/types/src/lib/config/hosts.d.ts
@@ -6,7 +6,6 @@ export declare const CHALLENGE_HOST: string;
 export declare const COMMUNITY_HOST: string;
 export declare const THRIVE_HOST: string;
 export declare const FORUM_HOST: string;
-export declare const PACTS_HOST: string;
 export declare const ONLINE_REVIEW_HOST: string;
 export declare const TCACADEMY_HOST: string;
 export declare const DEV_CENTER_HOST: string;


### PR DESCRIPTION
This reverts commit [cfab3a59fdce8e7cf0f264022d4c3b789cfef9af](https://github.com/topcoder-platform/universal-navigation/commit/cfab3a59fdce8e7cf0f264022d4c3b789cfef9af).

This is in order to release the uninav with the WalletApp enabled.