### PR TITLE
Remove talent spotlight in footer

### DIFF
--- a/src/lib/config/nav-menu/footer-nav-items.ts
+++ b/src/lib/config/nav-menu/footer-nav-items.ts
@@ -49,10 +49,10 @@ export const footerNavItems: NavMenuItem = {
                 label: 'Expertise',
                 url: getWordpressUrl('/customer/expertise'),
               },
-              {
-                label: 'Talent Spotlight',
-                url: getWordpressUrl('/releasenotes'),
-              },
+              // {
+              //   label: 'Talent Spotlight',
+              //   url: getWordpressUrl('/releasenotes'),
+              // },
             ]
         },
         {


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TOP-1476 - Clean up topcoder.com footer

This pr removes the "talent spotlight" link in footer