### PR TITLE
Adds a way to trigger the uninav's signin modal from outside -> dev

### DIFF
--- a/src/lib/components/user-area/UserArea.svelte
+++ b/src/lib/components/user-area/UserArea.svelte
@@ -14,6 +14,7 @@
   import styles from './UserArea.module.scss'
   import Completedness from './Completedness.svelte';
   import SigninPopup from './SigninPopup.svelte';
+  import { appPubSub } from '../../../main';
 
   const ctx = getAppContext();
 
@@ -70,6 +71,9 @@
   $: isReady && user?.handle && fetchProfileDetails();
 
   onMount(async () => {
+    appPubSub.subscribe('signup', () => handleSignin('signup'))
+    appPubSub.subscribe('login', () => handleSignin('login'))
+
     if (autoFetchUser !== true) {
       return;
     }

--- a/src/lib/utils/pubsub.ts
+++ b/src/lib/utils/pubsub.ts
@@ -1,0 +1,34 @@
+export type EventHandler<T = any> = (data: T) => void;
+
+export class PubSub {
+  private events: { [key: string]: EventHandler<any>[] } = {};
+
+  // Publishes an event to all subscribers
+  publish<T = any>(name: string, data: T): void {
+    const handlers = this.events[name];
+    if (!handlers) return;
+
+    handlers.forEach(handler => {
+      handler(data);
+    });
+  }
+
+  // Subscribes a handler to an event
+  subscribe<T = any>(name: string, handler: EventHandler<T>): void {
+    if (!this.events[name]) {
+      this.events[name] = [];
+    }
+    this.events[name].push(handler);
+  }
+
+  // Unsubscribes a handler from an event
+  unsubscribe<T = any>(name: string, handler: EventHandler<T>): void {
+    const handlers = this.events[name];
+    if (!handlers) return;
+
+    const handlerIdx = handlers.indexOf(handler);
+    if (handlerIdx !== -1) {
+      handlers.splice(handlerIdx, 1);
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,10 +4,12 @@ import type { Writable } from 'svelte/store'
 import { buildContext, type AuthUser, type NavigationHandler, type SupportMeta } from './lib/app-context'
 import { initUserflow, triggerFlow } from 'lib/functions/integrations/userflow';
 import { loadNudgeApp } from './lib/functions/load-nudge-app'
+import { PubSub } from './lib/utils/pubsub';
 
 import 'lib/styles/main.scss';
 
 export * from './lib/app-context'
+export const appPubSub = new PubSub();
 
 export type NavigationType = (
   | 'footer'
@@ -157,6 +159,10 @@ function execQueueCall(method: TcUniNavMethods, ...args: any[]) {
 
   else if (method === 'triggerFlow') {
     triggerFlow.call(null, ...args)
+  }
+
+  else if (method === 'trigger') {
+    appPubSub.publish.call(appPubSub, ...args);
   }
 
   else {

--- a/types/src/lib/utils/pubsub.d.ts
+++ b/types/src/lib/utils/pubsub.d.ts
@@ -1,0 +1,7 @@
+export declare type EventHandler<T = any> = (data: T) => void;
+export declare class PubSub {
+    private events;
+    publish<T = any>(name: string, data: T): void;
+    subscribe<T = any>(name: string, handler: EventHandler<T>): void;
+    unsubscribe<T = any>(name: string, handler: EventHandler<T>): void;
+}

--- a/types/src/main.d.ts
+++ b/types/src/main.d.ts
@@ -1,6 +1,8 @@
 import { type AuthUser, type NavigationHandler, type SupportMeta } from './lib/app-context';
+import { PubSub } from './lib/utils/pubsub';
 import 'lib/styles/main.scss';
 export * from './lib/app-context';
+export declare const appPubSub: PubSub;
 export declare type NavigationType = ('footer' | 'marketing' | 'tool');
 export declare type NavigationAppProps = {
     type?: NavigationType;


### PR DESCRIPTION
This PR adds a method on uninav that allows anyone to trigger the "signin" modal within uninav.

The call will look like:
- signup: `tcUniNav('trigger', 'signup')`
- login: `tcUniNav('trigger', 'login')`