### PR TITLE
TOP-1650 - update talent links

### DIFF
--- a/src/lib/config/hosts.ts
+++ b/src/lib/config/hosts.ts
@@ -32,3 +32,4 @@ export const ONBOARDING_HOST: string = `https://onboarding.${TC_DOMAIN}`;
 export const TALENT_SEARCH_HOST: string = `https://talent-search.${TC_DOMAIN}`;
 export const ACCOUNT_SETTINGS_HOST: string = `https://account-settings.${TC_DOMAIN}`;
 export const WALLETAPP_HOST: string = `https://wallet.${TC_DOMAIN}`;
+export const TALENT_TOP_NAV_URL: string = getEnvValue('VITE_TALENT_TOP_NAV_URL', 'https://www.topcoder.about-talent.com');

--- a/src/lib/config/nav-menu/all-nav-items.config.ts
+++ b/src/lib/config/nav-menu/all-nav-items.config.ts
@@ -13,6 +13,7 @@ import {
     PLATFORM_APP_HOST,
     WALLETAPP_HOST,
     WORK_MANAGER_HOST,
+    TALENT_TOP_NAV_URL,
 } from '..';
 
 export const allNavItems: {[key: string]: NavMenuItem} = {
@@ -27,6 +28,10 @@ export const allNavItems: {[key: string]: NavMenuItem} = {
     product: {
       label: 'Product',
       url: getWordpressUrl('/customer/product'),
+    },
+    talent: {
+      label: 'Talent',
+      url: TALENT_TOP_NAV_URL,
     },
 
     ai360Platform: {

--- a/src/lib/config/nav-menu/footer-nav-items.ts
+++ b/src/lib/config/nav-menu/footer-nav-items.ts
@@ -9,10 +9,6 @@ export const footerNavItems: NavMenuItem = {
             label: 'Info',
             children: [
               {
-                label: 'About Topcoder',
-                url: getWordpressUrl('/about-us'),
-              },
-              {
                 label: 'Customer Stories',
                 url: getWordpressUrl('/customer/success-stories'),
               },
@@ -47,12 +43,9 @@ export const footerNavItems: NavMenuItem = {
               },
               {
                 label: 'Expertise',
-                url: getWordpressUrl('/customer/expertise'),
+                url: getWordpressUrl('/ai'),
               },
-              // {
-              //   label: 'Talent Spotlight',
-              //   url: getWordpressUrl('/releasenotes'),
-              // },
+              allNavItems.talent,
             ]
         },
         {

--- a/src/lib/config/nav-menu/main-navigation.config.ts
+++ b/src/lib/config/nav-menu/main-navigation.config.ts
@@ -6,4 +6,5 @@ export const mainNavigationItems: NavMenuItem[] = [
   allNavItems.product,
   allNavItems.pricing,
   allNavItems.demo,
+  allNavItems.talent,
 ]

--- a/types/src/lib/config/hosts.d.ts
+++ b/types/src/lib/config/hosts.d.ts
@@ -16,3 +16,4 @@ export declare const ONBOARDING_HOST: string;
 export declare const TALENT_SEARCH_HOST: string;
 export declare const ACCOUNT_SETTINGS_HOST: string;
 export declare const WALLETAPP_HOST: string;
+export declare const TALENT_TOP_NAV_URL: string;


### PR DESCRIPTION
- https://topcoder.atlassian.net/browse/TOP-1650 - Add Talent to top level UniNav
Adds new section to top UniNav called “Talent” next to Demo. It will link to www.topcoder.about-talent.com
![image](https://github.com/topcoder-platform/universal-navigation/assets/2527433/5104c540-e89f-4d8d-86b3-50f50566fadf)

- https://topcoder.atlassian.net/browse/TOP-1651 - Add Talent to the footer after Expertise
- https://topcoder.atlassian.net/browse/TOP-1654 - Remove "About Topcoder" in Footer
- https://topcoder.atlassian.net/browse/TOP-1652 - Updates Expertise link in footer to topcoder.com/ai